### PR TITLE
Remove operator and value in payload if they are None in AdvancedParams

### DIFF
--- a/pynequa/api/api.py
+++ b/pynequa/api/api.py
@@ -5,13 +5,13 @@ import requests
 
 
 class API:
-    '''
-        API Class handles all HTTP Requests
+    """
+    API Class handles all HTTP Requests
 
-        Attributes:
-            base_url(string): REST API base URL for Sinequa instance
-            access_token(string): token for Sinequa authentication
-    '''
+    Attributes:
+        base_url(string): REST API base URL for Sinequa instance
+        access_token(string): token for Sinequa authentication
+    """
 
     def __init__(self, access_token: str, base_url: str) -> None:
         if not access_token or not base_url:
@@ -21,9 +21,7 @@ class API:
         self.base_url = base_url
 
     def _get_headers(self) -> Dict:
-        headers = {
-            "Authorization": f"Bearer {self.access_token}"
-        }
+        headers = {"Authorization": f"Bearer {self.access_token}"}
         return headers
 
     def _get_url(self, endpoint) -> str:
@@ -31,19 +29,22 @@ class API:
 
     def get(self, endpoint) -> Dict:
         """
-            This method handles GET method.
+        This method handles GET method.
         """
-        session = requests.Session()
-        resp = session.get(self._get_url(endpoint=endpoint),
-                           headers=self._get_headers())
-        session.close
-        return resp.json()
+        with requests.Session() as session:
+            resp = session.get(
+                self._get_url(endpoint=endpoint), headers=self._get_headers()
+            )
+            return resp.json()
 
     def post(self, endpoint, payload) -> Dict:
         """
-            This method handles POST method.
+        This method handles POST method.
         """
-        session = requests.Session()
-        resp = session.post(self._get_url(endpoint=endpoint),
-                            headers=self._get_headers(), json=payload)
-        return resp.json()
+        with requests.Session() as session:
+            resp = session.post(
+                self._get_url(endpoint=endpoint),
+                headers=self._get_headers(),
+                json=payload,
+            )
+            return resp.json()

--- a/pynequa/models.py
+++ b/pynequa/models.py
@@ -31,6 +31,7 @@ class TreeParams(AbstractParams):
             Possible values: '=', '!=', '<', '<=', '>=', '>', 'between', 'not between'.
         value (str): The filter value (required).
     """
+
     box: str = ""
     column: str = ""
     op: str = ""
@@ -85,7 +86,7 @@ class OpenParams(AbstractParams):
 class AdvancedParams(AbstractParams):
     col_name: str = ""
     col_value: str = None
-    value:  str or int = None
+    value: str or int = None
     operator: str = None
     debug: bool = False
 
@@ -96,9 +97,12 @@ class AdvancedParams(AbstractParams):
         """
         payload = {
             self.col_name: self.col_value,
-            "value": self.value,
-            "operator": self.operator
         }
+
+        if self.value:
+            payload["value"] = self.value
+        if self.operator:
+            payload["operator"] = self.operator
 
         if self.debug:
             logger.debug(payload)
@@ -111,8 +115,7 @@ class QueryParams(AbstractParams):
     name: str = ""  # required
     action: Optional[str] = None
     search_text: str = ""  # required
-    select_params: Optional[List[SelectParams]
-                            ] = field(default_factory=lambda: [])
+    select_params: Optional[List[SelectParams]] = field(default_factory=lambda: [])
     additional_select_clause: Optional[str] = None
     additional_where_clause: Optional[str] = None
     open_params: Optional[List[OpenParams]] = field(default_factory=lambda: [])

--- a/pynequa/models.py
+++ b/pynequa/models.py
@@ -95,10 +95,10 @@ class AdvancedParams(AbstractParams):
         This method generates payload for
         AdvancedParams.
         """
-        payload = {
-            self.col_name: self.col_value,
-        }
-
+        payload = {}
+        # To prevent payloads with empty values
+        if self.col_name and self.col_value:
+            payload[self.col_name] = self.col_value
         if self.value:
             payload["value"] = self.value
         if self.operator:


### PR DESCRIPTION
Major Fixes:
- Removes the keys `operator` and `value` in `pynequa.AdvanedParams` payload generation if they are empty/none/null. This fixes the issue when we want to filter (say by "collection") and we don't want to apply any operator.

Sample:

```python
{
    'app': 'vanilla-search',
    'query': {
        'name': 'query',
        'text': 'himawari',
        'isFirstpage': False,
        'strictRefine': False,
        'removeDuplicates': False,
        'action': 'search',
        'page': 1,
        'pageSize': 10,
        'advanced': {
            'collection': '/user_needs_database/snwg-assessments-2020/',
            # 'value': None, 'operator': None,
        }
    }
}
```